### PR TITLE
#4 Settings page fix

### DIFF
--- a/app/src/main/java/com/manichord/mgit/ui/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/manichord/mgit/ui/fragments/SettingsFragment.java
@@ -1,16 +1,19 @@
 package com.manichord.mgit.ui.fragments;
 
 import android.content.Context;
-import android.content.Intent;
+//import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import androidx.core.app.TaskStackBuilder;
+//import androidx.core.app.TaskStackBuilder;
+import androidx.preference.EditTextPreference;
+import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
+import androidx.preference.SwitchPreferenceCompat;
 
-import com.manichord.mgit.utils.BasicFunctions;
+//import com.manichord.mgit.utils.BasicFunctions;
 import com.manichord.mgitt.R;
-import com.manichord.mgit.ui.RepoListActivity;
+//import com.manichord.mgit.ui.RepoListActivity;
 
 public class SettingsFragment extends PreferenceFragmentCompat {
     private SharedPreferences.OnSharedPreferenceChangeListener mListener;
@@ -25,13 +28,24 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         prefMgr.setSharedPreferencesMode(Context.MODE_PRIVATE);
 
         // Load the preferences from an XML resource
-        addPreferencesFromResource(R.xml.preferences);
+        if(savedInstanceState != null) { // prevent to load preferences multiple times to Fragment
+            addPreferencesFromResource(R.xml.preferences);
+        }
 
         final String themePrefKey = getString(R.string.pref_key_use_theme_id);
         final String gravatarPrefKey = getString(R.string.pref_key_use_gravatar);
         final String useEnglishPrefKey = getString(R.string.pref_key_use_english);
+        final String userNamePrefKey = getString(R.string.pref_key_git_user_name);
+        final String userEmailPrefKey = getString(R.string.pref_key_git_user_email);
+
+        ListPreference themePref = findPreference(themePrefKey);
+        SwitchPreferenceCompat gravatarPref = findPreference(gravatarPrefKey);
+        SwitchPreferenceCompat useEnglishPref = findPreference(useEnglishPrefKey);
+        EditTextPreference userNamePref =  findPreference(userNamePrefKey);
+        EditTextPreference userEmailPref = findPreference(userEmailPrefKey);
 
         mListener = (sharedPreferences, key) -> {
+            /*
             if (themePrefKey.equals(key) || useEnglishPrefKey.equals(key)) {
                 // nice trick to recreate the back stack, to ensure existing activities onCreate() are
                 // called to set new theme, courtesy of: http://stackoverflow.com/a/28799124/85472
@@ -44,7 +58,29 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                 BasicFunctions.getImageLoader().clearMemoryCache();
                 BasicFunctions.getImageLoader().clearDiskCache();
             }
+            */
+
+            // Attach a listener to update fields
+            if (themePref != null){
+                themePref.setValueIndex
+                    (Integer.parseInt(sharedPreferences.getString(themePrefKey, "")));
+            }
+            if (gravatarPref != null ){
+                gravatarPref.setChecked(sharedPreferences.getBoolean(gravatarPrefKey, true));
+            }
+            if (useEnglishPref != null){
+                useEnglishPref.setChecked(sharedPreferences.getBoolean(useEnglishPrefKey, false));
+            }
+            if (userNamePref != null) {
+                userNamePref.setSummary(sharedPreferences.getString(userNamePrefKey, ""));
+            }
+            if (userEmailPref != null) {
+                userEmailPref.setSummary(sharedPreferences.getString(userEmailPrefKey, ""));
+            }
         };
+
+        // Invoke callback manually to display the current values
+        mListener.onSharedPreferenceChanged(prefMgr.getSharedPreferences(), userNamePrefKey);
     }
 
     @Override


### PR DESCRIPTION
Closes #4 

@Meghdut-Mandal 
PR content:
Settings page not working properly. 

The fields now reflect the changes. 
The settings activity now not restarting after color theme change, because I commented previous code in mListener. This code restarts activity each time, so I decided to comment him. I don't know what is this code improving, because I do not see any changes after it. 
I also found a new bug, which is not mentioned in issue, but preferences were loaded to fragment multiple times. Bug is now fixed.